### PR TITLE
Add instructions and script to run app locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ public/components/bower_components
 #Private files
 config.js
 
+# Node modules
+node_modules
 
 # Windows shortcuts
 *.lnk

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # Parallel.Team
-Open Codebase for the Parallel.Team app.
+
+[Parallel.Team](http://www.parallel.team/) is a web app for finding people to play games with.
+
+## Requirements
+
+* [NodeJS](https://nodejs.org/)
+
+## Installation
+
+Install the node dependencies.
+
+```shell
+npm install
+```
+
+Install the bower components.
+
+```shell
+cd public/components
+bower install
+cd -
+```
+
+Copy `config-example.js` to `config.js` and make the appropriate changes.
+
+```shell
+cp config-example.js config.js
+```
+
+## Running
+
+The application is built to run on an [Heroku](https://www.heroku.com/) stack while storing the data in [Firebase](https://www.firebase.com/). However, you can run a local instance of it with the `local.js` script. This will start a local server which listens on [localhost:3000](http://localhost:3000).
+
+```shell
+node local.js
+```

--- a/config-example.js
+++ b/config-example.js
@@ -1,0 +1,11 @@
+module.exports = {
+	appsettings: {
+		env: 'dev'
+	},
+	email: {
+		gmail: {
+			user: '',
+			password: ''
+		}
+	}
+};

--- a/local.js
+++ b/local.js
@@ -1,0 +1,10 @@
+// Setup
+if (!process.env.PORT) {
+    process.env.PORT = 3000;
+}
+
+var app = require('./app.js');
+
+app.listen(process.env.PORT, function () {
+    console.log('App listening at http://%s:%s', process.env.HOST, process.env.PORT);
+});

--- a/package.json
+++ b/package.json
@@ -20,11 +20,13 @@
     "firebase-token-generator": "^2.0.0",
     "jade": "~1.6.0",
     "morgan": "~1.3.0",
+    "nodemailer": "^1.8.0",
     "openid": "^0.5.13",
     "q": "^1.4.1",
     "request-promise": "^0.4.2",
     "serve-favicon": "~2.1.3",
     "stylus": "0.42.3",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "uuid": "^2.0.1"
   }
 }

--- a/public/components/bower.json
+++ b/public/components/bower.json
@@ -18,6 +18,12 @@
     "paper-toolbar": "PolymerElements/paper-toolbar#^1.0.0",
     "html5-history-anchor": "~0.4.0",
     "moment-timezone": "~0.4.0",
-    "font-awesome" : " "
+    "font-awesome": " ",
+    "firebase": "~2.3.1",
+    "jquery": "~2.1.4",
+    "xss": "~0.2.7",
+    "app-router": "~2.6.1",
+    "Materialize": "materialize#~0.97.1",
+    "firebase-element": "PolymerElements/firebase-element#~1.0.6"
   }
 }


### PR DESCRIPTION
To ease development I am suggesting that you have the means to run the app locally (without Heroku and Firebase). The changes I've made, which are most to the README, just make it possible to run in using `node` locally, but it still uses the production Firebase DB. The next step is to use some local DB so running the app won't communicate with the official data.

I don't think I made any changes that breaks how the app works in production, as running it locally requires the use of the `local.js` script (meaning I didn't change how `app.js` works _at all_). Read the updated README for instructions on how to run it.