### PR TITLE
Add unit tests to backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ cp public/assets/app/js/app-config-example.js public/assets/app/js/app-config.js
 
 ## Running
 
-The application is built to run on an [Azure](https://azure.microsoft.com/en-us/) stack. However, you can run a local instance of it with the `bin/www` script. This will start a local server which listens on [localhost:3000](http://localhost:3000).
+The application is built to run on an [Azure](https://azure.microsoft.com/en-us/) stack. However, you can run a local instance of it with the `npm start` command. This will start a local server which listens on [localhost:3000](http://localhost:3000).
 
 ```shell
-node bin/www
+npm start
 ```
 
 All authentication is done via Firebase, so you will need to set it up to authenticate with Google/Facebook/Twitter or any other auth service you want to use.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Copy `public/assets/app/js/app-config-example.js` to `public/assets/app/js/app-c
 cp public/assets/app/js/app-config-example.js public/assets/app/js/app-config.js
 ```
 
-## Running
+## Development
 
 The application is built to run on an [Azure](https://azure.microsoft.com/en-us/) stack. However, you can run a local instance of it with the `npm start` command. This will start a local server which listens on [localhost:3000](http://localhost:3000).
 
@@ -45,3 +45,11 @@ npm start
 ```
 
 All authentication is done via Firebase, so you will need to set it up to authenticate with Google/Facebook/Twitter or any other auth service you want to use.
+
+### Testing
+
+Testing is run via the `npm test` command, but you need to be sure that you've installed the `devDependencies` (see the [npm Documentation](https://docs.npmjs.com/cli/install) for more information).
+
+```shell
+npm test
+```

--- a/config-example.js
+++ b/config-example.js
@@ -23,7 +23,7 @@ module.exports = {
         "appsecret" : "<Your Facebook App Secret>"
     },
     "steam" : {
-        "api_url" : 'http://api.steampowered.com/<interface_name>/<method_name>/<version>/?key=<api_key>&format=<format>',
+        "api_url" : 'http://api.steampowered.com/',
         "api_key" : '<Your Steam API Key>',
         "provider" : 'http://steamcommunity.com/openid'
     },

--- a/config-example.js
+++ b/config-example.js
@@ -16,32 +16,7 @@ module.exports = {
     },
     "giant_bomb": {
         "url" : "http://www.giantbomb.com/api/",
-        "key" : "<Your API Key>",
-        "endpoints" : {
-            "games" : "games",
-            "genres" : "genres",
-            "platforms" : "platforms",
-            "search" : "search"
-        },
-        "formats": {
-            "json" : "json",
-            "xml" : "xml"
-        },
-        "resources" : {
-            'game' : 'game',
-            'franchise' : 'franchise',
-            'character' : 'character',
-            'concept' : 'concept', 
-            'object' : 'object',
-            'location' : 'location',
-            'person' : 'person',
-            'company' : 'company',
-            'video' : 'video'
-        },
-        "limit" : 4,
-        "sample_url" : "http://www.giantbomb.com/api/game/3030-4725/?api_key=[YOUR-KEY]",
-        "sample_url_json" : "http://www.giantbomb.com/api/game/3030-4725/?api_key=[YOUR-KEY]&format=json&field_list=genres,name",
-        "sample_url_breakdown" : "http://www.giantbomb.com/api/[RESOURCE-TYPE]/[RESOURCE-ID]/?api_key=[YOUR-KEY]&format=[RESPONSE-DATA-FORMAT]&field_list=[COMMA-SEPARATED-LIST-OF-RESOURCE-FIELDS]"
+        "key" : "<Your API Key>"
     },
     "facebook" : {
         "appid" : "<Your Facebook App Id>",

--- a/config-example.js
+++ b/config-example.js
@@ -1,34 +1,28 @@
-var env = {
-    dev: 'dev',
-    test: 'test',
-    prod: 'prod'
-};
-
 module.exports = {
-    "appsettings" : {
-        "env" : env.dev
-    },
-    "email": {
-        "gmail": {
-            "user" : "",
-            "password" : ""
-        }
-    },
-    "giant_bomb": {
-        "url" : "http://www.giantbomb.com/api/",
-        "key" : "<Your API Key>"
-    },
-    "facebook" : {
-        "appid" : "<Your Facebook App Id>",
-        "appsecret" : "<Your Facebook App Secret>"
-    },
-    "steam" : {
-        "api_url" : 'http://api.steampowered.com/',
-        "api_key" : '<Your Steam API Key>',
-        "provider" : 'http://steamcommunity.com/openid'
-    },
-    "firebase" : {
-        "url" : '<Your Firebase Url>',
-        "secret" : '<Your Firebase Key>'
-    }
-}
+	appsettings: {
+		env: 'dev' // possible values: dev, test, prod
+	},
+	email: {
+		gmail: {
+			user: '',
+			password: ''
+		}
+	},
+	giant_bomb: {
+		url: 'http://www.giantbomb.com/api/',
+		key: '<Your API Key>'
+	},
+	facebook: {
+		appid: '<Your Facebook App Id>',
+		appsecret: '<Your Facebook App Secret>'
+	},
+	steam: {
+		api_url: 'http://api.steampowered.com/',
+		api_key: '<Your Steam API Key>',
+		provider: 'http://steamcommunity.com/openid'
+	},
+	firebase: {
+		url: '<Your Firebase Url>',
+		secret: '<Your Firebase Key>'
+	}
+};

--- a/giantbomb.js
+++ b/giantbomb.js
@@ -1,60 +1,20 @@
 /**
  * Created by Namdascious on 6/4/2015.
+ * Modified by Michael on 2015-10-22
  */
-var rp = require('request-promise');
-var config = require('./config.js');
-var http = require('http');
-var url = require('url');
+var requestPromise = require('request-promise');
+var config = require('./config');
 
-var giantbomb = {
+module.exports = {
+	getGames: function(query, max){
+		var gbRef = config.giant_bomb;
+		var limit = (max !== null && max !== undefined)
+			? max
+			: gbRef.limit;
+		var url = gbRef.url + 'search/?api_key=' + gbRef.key + '&limit='
+			+ limit + '&format=json&query="' + query
+			+ '"&resources=game&field_list=id,name,image,original_release_date';
 
-    getGames: function(query, max){
-        var gbRef = config.giant_bomb;
-        var limit = max !== null && max !== undefined ? max : gbRef.limit;
-        var gburl = gbRef.url + gbRef.endpoints.search + '/?api_key=' + gbRef.key + '&limit=' + limit + '&format=' + gbRef.formats.json + '&query="' + query + '"&resources=' + gbRef.resources.game + '&field_list=id,name,image,original_release_date';
-        return rp(gburl);
-        //if (config.appsettings.env == 'dev') {
-        //    return rp(gburl);
-        //}
-        //else {
-        //    if (process.env.PROXIMO_URL) {
-        //        var proxy = url.parse(process.env.PROXIMO_URL);
-        //        options = {
-        //            hostname: proxy.hostname,
-        //            port: proxy.port || 80,
-        //            uri: gburl,
-        //            headers: { "Proxy-Authorization" : 'Basic #{new Buffer(proxy.auth).toString("base64")}' }
-        //        };
-                
-        //        return rp(options);
-
-        //        //return http.get(options, function (res) {
-        //        //    console.log("status code", res.statusCode);
-        //        //    console.log("headers", res.headers);
-        //        //});
-        //    }
-        //}
-    },
-
-    getGame: function(){
-
-    },
-
-    getGenres: function(){
-
-    },
-
-    getGenre: function(){
-
-    },
-
-    getPlatforms: function(){
-
-    },
-
-    getPlatform: function(){
-
-    }
+		return requestPromise(url);
+	}
 };
-
-module.exports = giantbomb;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "node ./bin/www",
+    "test": "./node_modules/mocha/bin/mocha --recursive test"
   },
   "description": "lfg",
   "author": {
@@ -28,6 +29,10 @@
     "stylus": "0.42.3",
     "underscore": "^1.8.3",
     "uuid": "^2.0.1",
-    "websocket-driver" : "^0.6.2"
+    "websocket-driver": "^0.6.2"
+  },
+  "devDependencies": {
+    "mocha": "^2.3.3",
+    "mockery": "^1.4.0"
   }
 }

--- a/steam.js
+++ b/steam.js
@@ -1,52 +1,16 @@
 ﻿/**
  * Created by Namdascious.
  */
-var rp = require('request-promise');
-var _ = require('underscore');
-var config = require('./config.js');
+var requestPromise = require('request-promise');
+var config = require('./config');
 
-var steam_interface = {
-	news: 'ISteamNews',
-	user: 'ISteamUser',
-	userStats: 'ISteamUserStats'
-};
+module.exports = {
+	getSteamUser : function (userId) {
+		var url = config.steam.api_url
+			+ 'ISteamUser/GetPlayerSummaries/v0002/?key='
+			+ config.steam.api_key
+			+ '&format=json&steamids=' + userId;
 
-var steam_version = 'v0002';
-
-var steam_methods = [
-	{ name: 'getPlayerSummaries', method: { name: 'GetPlayerSummaries', version: 'v0002' } },
-	{ name: 'getFriendList', method: { name: 'GetFriendList', version: 'v0001' } },
-	{ name: 'getPlayerAchievements', method: { method: 'GetPlayerAchievements', version: 'v0001' } },
-	{ name: 'getUserStatsForGame', method: { name: 'GetUserStatsForGame', version: 'v0002' } },
-	{ name: 'getOwnedGames', method: { name: 'GetOwnedGames', version: 'v0001' } },
-	{ name: 'getRecentlyPlayedGames', method: { name: 'GetRecentlyPlayedGames', version: 'v0001' } },
-	{ name: 'isPlayingSharedGame', method: { name: 'IsPlayingSharedGame', version: 'v0001' } }
-];
-
-var steam_formats = {
-	json : 'json',
-	xml: 'xml'
-};
-
-var steam = {
-	getSteamUser : function (userid) {
-		
-		var steam_method = _.findWhere(steam_methods, { name: "getPlayerSummaries" });
-
-		var steam_api_url = config.steam.api_url
-							.replace('<interface_name>', steam_interface.user)
-							.replace('<method_name>', steam_method.method.name)
-							.replace('<version>', steam_method.method.version)
-							.replace('<api_key>', config.steam.api_key)
-							.replace('<format>', steam_formats.json);
-		return rp(steam_api_url + '&steamids=' + userid);
-	},
-
-	getSteamUserStats : function () {
-	},
-
-	getSteamNews : function () {
-	},
+		return requestPromise(url);
+	}
 }
-
-module.exports = steam;

--- a/test/giantbomb.js
+++ b/test/giantbomb.js
@@ -1,0 +1,47 @@
+var assert = require('assert'),
+	mockery = require('mockery');
+
+describe('giantbomb', function() {
+	var giantbomb;
+
+	before(function() {
+		var configMock = {
+				'giant_bomb': {
+					'url': 'http://www.giantbomb.com/api/',
+					'key': 'f735c8db9f30c3d62ff557e615b4a4e5f572d784',
+					'endpoints' : {
+			            'search' : 'search'
+					},
+					'formats': {
+						'json' : 'json'
+					},
+					'resources': {
+						'game' : 'game'
+					}
+				},
+			}
+		    requestPromiseMock = function(url) {
+				return url;
+			};
+
+		mockery.enable();
+		mockery.registerMock('request-promise', requestPromiseMock);
+		mockery.registerMock('./config.js', configMock);
+		mockery.registerAllowable('../giantbomb');
+
+		giantbomb = require('../giantbomb');
+	});
+
+	after(function() {
+		mockery.disable();
+	});
+
+	describe('getGames', function() {
+		it('should attempt to search for a list of games', function() {
+			var expected = 'http://www.giantbomb.com/api/search/?api_key=f735c8db9f30c3d62ff557e615b4a4e5f572d784&limit=10&format=json&query="test"&resources=game&field_list=id,name,image,original_release_date',
+				result = giantbomb.getGames('test', 10);
+
+			assert.equal(expected, result);
+		});
+	});
+});

--- a/test/giantbomb.js
+++ b/test/giantbomb.js
@@ -33,6 +33,7 @@ describe('giantbomb', function() {
 	});
 
 	after(function() {
+		mockery.deregisterAll();
 		mockery.disable();
 	});
 

--- a/test/giantbomb.js
+++ b/test/giantbomb.js
@@ -1,32 +1,23 @@
-var assert = require('assert'),
-	mockery = require('mockery');
+var assert = require('assert');
+var mockery = require('mockery');
 
 describe('giantbomb', function() {
 	var giantbomb;
 
 	before(function() {
 		var configMock = {
-				'giant_bomb': {
-					'url': 'http://www.giantbomb.com/api/',
-					'key': 'f735c8db9f30c3d62ff557e615b4a4e5f572d784',
-					'endpoints' : {
-			            'search' : 'search'
-					},
-					'formats': {
-						'json' : 'json'
-					},
-					'resources': {
-						'game' : 'game'
-					}
-				},
-			}
-		    requestPromiseMock = function(url) {
-				return url;
-			};
+			'giant_bomb': {
+				'url': 'http://www.giantbomb.com/api/',
+				'key': 'f735c8db9f30c3d62ff557e615b4a4e5f572d784'
+			},
+		};
+		var requestPromiseMock = function(url) {
+			return url;
+		};
 
 		mockery.enable();
 		mockery.registerMock('request-promise', requestPromiseMock);
-		mockery.registerMock('./config.js', configMock);
+		mockery.registerMock('./config', configMock);
 		mockery.registerAllowable('../giantbomb');
 
 		giantbomb = require('../giantbomb');
@@ -39,8 +30,8 @@ describe('giantbomb', function() {
 
 	describe('getGames', function() {
 		it('should attempt to search for a list of games', function() {
-			var expected = 'http://www.giantbomb.com/api/search/?api_key=f735c8db9f30c3d62ff557e615b4a4e5f572d784&limit=10&format=json&query="test"&resources=game&field_list=id,name,image,original_release_date',
-				result = giantbomb.getGames('test', 10);
+			var expected = 'http://www.giantbomb.com/api/search/?api_key=f735c8db9f30c3d62ff557e615b4a4e5f572d784&limit=10&format=json&query="test"&resources=game&field_list=id,name,image,original_release_date';
+			var result = giantbomb.getGames('test', 10);
 
 			assert.equal(expected, result);
 		});

--- a/test/steam.js
+++ b/test/steam.js
@@ -7,7 +7,7 @@ describe('steam', function() {
 	before(function() {
 		var configMock = {
 				'steam' : {
-					'api_url' : 'http://api.steampowered.com/<interface_name>/<method_name>/<version>/?key=<api_key>&format=<format>',
+					'api_url' : 'http://api.steampowered.com/',
 					'api_key' : 'TEST1234',
 					'provider' : 'http://steamcommunity.com/openid'
 				}
@@ -18,7 +18,7 @@ describe('steam', function() {
 
 		mockery.enable();
 		mockery.registerMock('request-promise', requestPromiseMock);
-		mockery.registerMock('./config.js', configMock);
+		mockery.registerMock('./config', configMock);
 		mockery.registerAllowable('../steam');
 
 		steam = require('../steam');
@@ -32,7 +32,7 @@ describe('steam', function() {
 	describe('getSteamUser', function() {
 		it('should attempt to get the details of a user', function() {
 			var expected = 'http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=TEST1234&format=json&steamids=test',
-				result = steam.getSteamUser('test', 10);
+				result = steam.getSteamUser('test');
 
 			assert.equal(expected, result);
 		});

--- a/test/steam.js
+++ b/test/steam.js
@@ -1,0 +1,40 @@
+var assert = require('assert'),
+	mockery = require('mockery');
+
+describe('steam', function() {
+	var steam;
+
+	before(function() {
+		var configMock = {
+				'steam' : {
+					'api_url' : 'http://api.steampowered.com/<interface_name>/<method_name>/<version>/?key=<api_key>&format=<format>',
+					'api_key' : 'TEST1234',
+					'provider' : 'http://steamcommunity.com/openid'
+				}
+			}
+		    requestPromiseMock = function(url) {
+				return url;
+			};
+
+		mockery.enable();
+		mockery.registerMock('request-promise', requestPromiseMock);
+		mockery.registerMock('./config.js', configMock);
+		mockery.registerAllowable('../steam');
+
+		steam = require('../steam');
+	});
+
+	after(function() {
+		mockery.deregisterAll();
+		mockery.disable();
+	});
+
+	describe('getSteamUser', function() {
+		it('should attempt to get the details of a user', function() {
+			var expected = 'http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=TEST1234&format=json&steamids=test',
+				result = steam.getSteamUser('test', 10);
+
+			assert.equal(expected, result);
+		});
+	});
+});


### PR DESCRIPTION
This was mostly an exercise in tidying up and removing cruft, but I added unit tests to the `giantbomb` and `steam` modules to make sure that my changes didn't break anything. You should probably check out the new config example in case I removed something that is necessary: https://github.com/Parallel-Platform/Parallel.Team/blob/backend-testing/config-example.js

Also be aware that the new `steam`>`api_url` is a basic one without the `<replace this text>` sections.