### PR TITLE
Close request when clicking on the overlay

### DIFF
--- a/public/views/recent-requests.html
+++ b/public/views/recent-requests.html
@@ -255,8 +255,17 @@
             margin-bottom: 5px;
         }
 
-        .overlay-cover {
+        .overlay-cover-background {
             background-color: rgba(0,0,0,0.75);
+            bottom: 0;
+            left: 0;
+            position: absolute;
+            right: 0;
+            top: 0;
+        }
+
+        .overlay-cover-background + .overlay-card {
+	        position: relative;
         }
 
         .overlay-card {
@@ -527,6 +536,7 @@
 
         <!-- Request Details Overlay-->
         <div id="details_overlay" class="overlay-cover layout horizontal center-center" style="width:100%; height:100% !important; z-index:10000 !important; position:absolute; display:none;">
+	        <div id="details_overlay_background" class="overlay-cover-background" on-click="closeOverlay"></div>
             <div id="details_overlay_content" class="white overlay-card" style="width:100%; max-width:1000px; height:92% !important; border-radius:5px;">
                 <div class="layout vertical white" style="border-radius:5px;">
                     <div class="layout horizontal">

--- a/public/views/request-page.html
+++ b/public/views/request-page.html
@@ -309,8 +309,17 @@
             margin-bottom: 5px;
         }
 
-        .overlay-cover {
+        .overlay-cover-background {
             background-color: rgba(0,0,0,0.75);
+            bottom: 0;
+            left: 0;
+            position: absolute;
+            right: 0;
+            top: 0;
+        }
+
+        .overlay-cover-background + .overlay-card {
+	        position: relative;
         }
 
         .overlay-card {
@@ -590,6 +599,7 @@
 
         <!-- Request Details Overlay-->
         <div id="details_overlay" class="overlay-cover layout horizontal center-center" style="width:100%; height:100% !important; z-index:10000 !important; position:fixed; display:none;">
+            <div id="details_overlay_background" class="overlay-cover-background" on-click="closeOverlay"></div>
             <div id="details_overlay_content" class="white overlay-card" style="width:100%; max-width:1000px; height:92% !important; border-radius:5px;">
                 <div class="layout vertical white" style="border-radius:5px;">
                     <div class="layout horizontal">


### PR DESCRIPTION
Closes the request when you click on the dark background around the request.

Solves: https://trello.com/c/5getZcKW/189-clicking-outside-a-request-closes-it
